### PR TITLE
chore: set npm registry info

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+@ayugioh2003:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+shamefully-hoist=true


### PR DESCRIPTION
# Why

set github npm registry info