### PR TITLE
chore: change access level to public in changeset config and update c…

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "package2": "pnpm --filter=@ayugioh2003/package2",
     "changeset": "changeset",
     "ci:version": "changeset version",
-    "ci:publish": "changeset publish --access public",
+    "ci:publish": "changeset publish",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
因為預設是 restrict, 而非 public 的 npm 要收費
需要讓 npm package 是 public 

- https://github.com/changesets/changesets/blob/main/packages/cli/README.md#init